### PR TITLE
added labels for sum and count statments in histogram

### DIFF
--- a/src/prometheus_handler.go
+++ b/src/prometheus_handler.go
@@ -84,11 +84,12 @@ func makePromHistogram(label string, histogram map[string]int, MLName string, ML
 		MLValue = MLName
 	}
 	for _, bound := range bounds {
-		entry := fmt.Sprintf(`%s_bucket{le="%s", %s="%s"} %d`, label, bound, strings.TrimRight(MLName, "bt"), MLValue, histogram[bound])
-		output += "\n" + entry
-	}
-	entry := fmt.Sprintf("%s_count %d", label, histogram["+inf"])
-	output += "\n\n" + entry + "\n"
+        entry := fmt.Sprintf(`%s_bucket{%s="%s", le="%s",} %d`, label, strings.TrimRight(MLName, "bt"), MLValue, bound,  histogram[bound])
+        output += "\n" + entry
+    }
+    entry1 := fmt.Sprintf(`%s_sum{%s="%s"} %d`, label,strings.TrimRight(MLName, "bt"), MLValue, histogram["+inf"])
+    entry2 := fmt.Sprintf(`%s_count{%s="%s"} %d`, label,strings.TrimRight(MLName, "bt"), MLValue, histogram["+inf"])
+    output += "\n" + entry1 + "\n"+ entry2 + "\n"
 	return output
 }
 


### PR DESCRIPTION
```
# HELP hist_Permission1 histogram output
# TYPE hist_Permission1 histogram
hist_Permission1_bucket{bpftrace2434e1fd6e2c45749011cf601670536611beedb0a3ee43a6aadaa2e989882d7e202309150959361="",le="+Inf"} 3
hist_Permission1_sum{bpftrace2434e1fd6e2c45749011cf601670536611beedb0a3ee43a6aadaa2e989882d7e202309150959361=""} 3
hist_Permission1_count{bpftrace2434e1fd6e2c45749011cf601670536611beedb0a3ee43a6aadaa2e989882d7e202309150959361=""} 3
hist_Permission1_bucket{bpftrace2434e1fd6e2c45749011cf601670536611beedb0a3ee43a6aadaa2e989882d7e202309150959361="Permission1",le="65536"} 2
hist_Permission1_bucket{bpftrace2434e1fd6e2c45749011cf601670536611beedb0a3ee43a6aadaa2e989882d7e202309150959361="Permission1",le="131072"} 1
hist_Permission1_bucket{bpftrace2434e1fd6e2c45749011cf601670536611beedb0a3ee43a6aadaa2e989882d7e202309150959361="Permission1",le="+Inf"} 3
hist_Permission1_sum{bpftrace2434e1fd6e2c45749011cf601670536611beedb0a3ee43a6aadaa2e989882d7e202309150959361="Permission1"} 0
hist_Permission1_count{bpftrace2434e1fd6e2c45749011cf601670536611beedb0a3ee43a6aadaa2e989882d7e202309150959361="Permission1"} 0
```
The node exporter was adding additional sum,count and bucket fields like above, So the prometheus node exporter was unable to scrape these metrics.
so in order to fix the issue i added labels to sum and count statements of histogram.
